### PR TITLE
Folia support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://oss.sonatype.org/content/repositories/snapshots")
-    maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
+    maven("https://repo.helpch.at/releases/")
     maven("https://repo.codemc.io/repository/maven-public/")
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
 }
@@ -30,7 +30,7 @@ dependencies {
     api("net.kyori:adventure-text-minimessage:4.16.0")
     api("net.kyori:adventure-platform-bukkit:4.3.2")
     compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
-    compileOnly("me.clip:placeholderapi:2.10.10")
+    compileOnly("me.clip:placeholderapi:2.11.6")
     compileOnly("com.mojang:authlib:1.5.25")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")

--- a/src/main/java/dev/aurelium/slate/Slate.java
+++ b/src/main/java/dev/aurelium/slate/Slate.java
@@ -12,6 +12,7 @@ import dev.aurelium.slate.menu.MenuFileGenerator;
 import dev.aurelium.slate.menu.MenuLoader;
 import dev.aurelium.slate.menu.MenuOpener;
 import dev.aurelium.slate.option.SlateOptions;
+import dev.aurelium.slate.scheduler.Scheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -27,6 +28,7 @@ import java.util.function.Consumer;
 public class Slate {
 
     private final JavaPlugin plugin;
+    private final Scheduler scheduler;
     private final ContextManager contextManager;
     private final InventoryManager inventoryManager;
     private final ActionManager actionManager;
@@ -40,8 +42,9 @@ public class Slate {
 
     public Slate(JavaPlugin plugin, SlateOptions options) {
         this.plugin = plugin;
+        this.scheduler = Scheduler.createScheduler(plugin);
         this.contextManager = new ContextManager();
-        this.inventoryManager = new InventoryManager(plugin);
+        this.inventoryManager = new InventoryManager(plugin, scheduler);
         inventoryManager.init();
         this.actionManager = new ActionManager(this);
         this.placeholderAPIEnabled = Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI");
@@ -156,6 +159,10 @@ public class Slate {
 
     public SlateOptions getOptions() {
         return options;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
     }
 
     /**

--- a/src/main/java/dev/aurelium/slate/action/CommandAction.java
+++ b/src/main/java/dev/aurelium/slate/action/CommandAction.java
@@ -23,9 +23,9 @@ public class CommandAction extends Action {
     public void execute(Player player, MenuInventory menuInventory, InventoryContents contents) {
         String formattedCommand = formatCommand(player, command);
         if (executor == Executor.CONSOLE) {
-            Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), formattedCommand);
+            slate.getScheduler().runGlobal(() -> Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), formattedCommand));
         } else if (executor == Executor.PLAYER) {
-            player.performCommand(formattedCommand);
+            slate.getScheduler().run(player, () -> player.performCommand(formattedCommand));
         }
     }
 

--- a/src/main/java/dev/aurelium/slate/inv/InventoryManager.java
+++ b/src/main/java/dev/aurelium/slate/inv/InventoryManager.java
@@ -37,6 +37,7 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 public class InventoryManager {
@@ -57,9 +58,9 @@ public class InventoryManager {
         this.scheduler = scheduler;
         this.pluginManager = Bukkit.getPluginManager();
 
-        this.inventories = new HashMap<>();
-        this.contents = new HashMap<>();
-        this.updateTasks = new HashMap<>();
+        this.inventories = new ConcurrentHashMap<>();
+        this.contents = new ConcurrentHashMap<>();
+        this.updateTasks = new ConcurrentHashMap<>();
 
         this.defaultOpeners = Arrays.asList(
                 new ChestInventoryOpener(),

--- a/src/main/java/dev/aurelium/slate/inv/InventoryManager.java
+++ b/src/main/java/dev/aurelium/slate/inv/InventoryManager.java
@@ -140,9 +140,7 @@ public class InventoryManager {
     protected void scheduleUpdateTask(Player p, SmartInventory inv) {
         final InventoryContents inventoryContents = contents.get(p.getUniqueId());
 
-        WrappedTask task = scheduler.runTimer(p, () ->
-                inv.getProvider().update(p, inventoryContents), 1, 1);
-
+        WrappedTask task = scheduler.runTimer(p, () -> inv.getProvider().update(p, inventoryContents), 1, 1);
         this.updateTasks.put(p.getUniqueId(), task);
     }
 

--- a/src/main/java/dev/aurelium/slate/inv/SmartInventory.java
+++ b/src/main/java/dev/aurelium/slate/inv/SmartInventory.java
@@ -92,6 +92,7 @@ public class SmartInventory {
             Inventory handle = opener.open(this, player);
 
             this.manager.setInventory(player, this);
+            this.manager.cancelUpdateTask(player);
             this.manager.scheduleUpdateTask(player, this);
 
             return handle;

--- a/src/main/java/dev/aurelium/slate/inv/SmartInvsPlugin.java
+++ b/src/main/java/dev/aurelium/slate/inv/SmartInvsPlugin.java
@@ -16,6 +16,7 @@
 
 package dev.aurelium.slate.inv;
 
+import dev.aurelium.slate.scheduler.Scheduler;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class SmartInvsPlugin extends JavaPlugin {
@@ -38,7 +39,7 @@ public class SmartInvsPlugin extends JavaPlugin {
 
     public static void setPlugin(JavaPlugin javaPlugin) {
         instance = javaPlugin;
-        invManager = new InventoryManager(javaPlugin);
+        invManager = new InventoryManager(javaPlugin, Scheduler.createScheduler(javaPlugin));
         invManager.init();
     }
 

--- a/src/main/java/dev/aurelium/slate/menu/MenuOpener.java
+++ b/src/main/java/dev/aurelium/slate/menu/MenuOpener.java
@@ -30,13 +30,15 @@ public class MenuOpener {
      * @param page The page number to open, 0 is the first page
      */
     public void openMenu(Player player, String name, Map<String, Object> properties, int page) {
-        try {
-            openMenuUnchecked(player, name, properties, page);
-        } catch (Exception e) {
-            player.closeInventory();
-            slate.getPlugin().getLogger().warning("Error opening Slate menu " + name);
-            e.printStackTrace();
-        }
+        slate.getScheduler().run(player, () -> {
+            try {
+                openMenuUnchecked(player, name, properties, page);
+            } catch (Exception e) {
+                player.closeInventory();
+                slate.getPlugin().getLogger().warning("Error opening Slate menu " + name);
+                e.printStackTrace();
+            }
+        });
     }
 
     public void openMenuUnchecked(Player player, String name, Map<String, Object> properties, int page) {

--- a/src/main/java/dev/aurelium/slate/scheduler/BukkitScheduler.java
+++ b/src/main/java/dev/aurelium/slate/scheduler/BukkitScheduler.java
@@ -2,6 +2,7 @@ package dev.aurelium.slate.scheduler;
 
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
 public class BukkitScheduler extends Scheduler {
     public BukkitScheduler(JavaPlugin plugin) {
@@ -9,22 +10,26 @@ public class BukkitScheduler extends Scheduler {
     }
 
     @Override
-    public void run(Player player, Runnable runnable) {
-        plugin.getServer().getScheduler().runTask(plugin, runnable);
+    public WrappedTask run(Player player, Runnable runnable) {
+        BukkitTask task = plugin.getServer().getScheduler().runTask(plugin, runnable);
+        return new WrappedTask(task);
     }
 
     @Override
-    public void runGlobal(Runnable runnable) {
-        run(null, runnable);
+    public WrappedTask runGlobal(Runnable runnable) {
+        BukkitTask task = plugin.getServer().getScheduler().runTask(plugin, runnable);
+        return new WrappedTask(task);
     }
 
     @Override
-    public void runLater(Player player, Runnable runnable, long delay) {
-        plugin.getServer().getScheduler().runTaskLater(plugin, runnable, delay);
+    public WrappedTask runLater(Player player, Runnable runnable, long delay) {
+        BukkitTask task = plugin.getServer().getScheduler().runTaskLater(plugin, runnable, delay);
+        return new WrappedTask(task);
     }
 
     @Override
-    public void runTimer(Player player, Runnable runnable, long delay, long period) {
-        plugin.getServer().getScheduler().runTaskTimer(plugin, runnable, delay, period);
+    public WrappedTask runTimer(Player player, Runnable runnable, long delay, long period) {
+        BukkitTask task =  plugin.getServer().getScheduler().runTaskTimer(plugin, runnable, delay, period);
+        return new WrappedTask(task);
     }
 }

--- a/src/main/java/dev/aurelium/slate/scheduler/BukkitScheduler.java
+++ b/src/main/java/dev/aurelium/slate/scheduler/BukkitScheduler.java
@@ -1,0 +1,30 @@
+package dev.aurelium.slate.scheduler;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class BukkitScheduler extends Scheduler {
+    public BukkitScheduler(JavaPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void run(Player player, Runnable runnable) {
+        plugin.getServer().getScheduler().runTask(plugin, runnable);
+    }
+
+    @Override
+    public void runGlobal(Runnable runnable) {
+        run(null, runnable);
+    }
+
+    @Override
+    public void runLater(Player player, Runnable runnable, long delay) {
+        plugin.getServer().getScheduler().runTaskLater(plugin, runnable, delay);
+    }
+
+    @Override
+    public void runTimer(Player player, Runnable runnable, long delay, long period) {
+        plugin.getServer().getScheduler().runTaskTimer(plugin, runnable, delay, period);
+    }
+}

--- a/src/main/java/dev/aurelium/slate/scheduler/PaperScheduler.java
+++ b/src/main/java/dev/aurelium/slate/scheduler/PaperScheduler.java
@@ -1,5 +1,6 @@
 package dev.aurelium.slate.scheduler;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -10,22 +11,26 @@ public class PaperScheduler extends Scheduler {
     }
 
     @Override
-    public void run(Player player, Runnable runnable) {
-        player.getScheduler().run(plugin, (t) -> runnable.run(), null);
+    public WrappedTask run(Player player, Runnable runnable) {
+        ScheduledTask task = player.getScheduler().run(plugin, (t) -> runnable.run(), null);
+        return new WrappedTask(task);
     }
 
     @Override
-    public void runGlobal(Runnable runnable) {
-        Bukkit.getGlobalRegionScheduler().run(plugin, (t) -> runnable.run());
+    public WrappedTask runGlobal(Runnable runnable) {
+        ScheduledTask task = Bukkit.getGlobalRegionScheduler().run(plugin, (t) -> runnable.run());
+        return new WrappedTask(task);
     }
 
     @Override
-    public void runLater(Player player, Runnable runnable, long delay) {
-        player.getScheduler().runDelayed(plugin, (t) -> runnable.run(), null, delay);
+    public WrappedTask runLater(Player player, Runnable runnable, long delay) {
+        ScheduledTask task = player.getScheduler().runDelayed(plugin, (t) -> runnable.run(), null, delay);
+        return new WrappedTask(task);
     }
 
     @Override
-    public void runTimer(Player player, Runnable runnable, long delay, long period) {
-        player.getScheduler().runAtFixedRate(plugin, (t) -> runnable.run(), null, delay, period);
+    public WrappedTask runTimer(Player player, Runnable runnable, long delay, long period) {
+        ScheduledTask task = player.getScheduler().runAtFixedRate(plugin, (t) -> runnable.run(), null, delay, period);
+        return new WrappedTask(task);
     }
 }

--- a/src/main/java/dev/aurelium/slate/scheduler/PaperScheduler.java
+++ b/src/main/java/dev/aurelium/slate/scheduler/PaperScheduler.java
@@ -1,0 +1,31 @@
+package dev.aurelium.slate.scheduler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class PaperScheduler extends Scheduler {
+    public PaperScheduler(JavaPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void run(Player player, Runnable runnable) {
+        player.getScheduler().run(plugin, (t) -> runnable.run(), null);
+    }
+
+    @Override
+    public void runGlobal(Runnable runnable) {
+        Bukkit.getGlobalRegionScheduler().run(plugin, (t) -> runnable.run());
+    }
+
+    @Override
+    public void runLater(Player player, Runnable runnable, long delay) {
+        player.getScheduler().runDelayed(plugin, (t) -> runnable.run(), null, delay);
+    }
+
+    @Override
+    public void runTimer(Player player, Runnable runnable, long delay, long period) {
+        player.getScheduler().runAtFixedRate(plugin, (t) -> runnable.run(), null, delay, period);
+    }
+}

--- a/src/main/java/dev/aurelium/slate/scheduler/Scheduler.java
+++ b/src/main/java/dev/aurelium/slate/scheduler/Scheduler.java
@@ -1,0 +1,28 @@
+package dev.aurelium.slate.scheduler;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public abstract class Scheduler {
+    protected final JavaPlugin plugin;
+
+    public Scheduler(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public abstract void run(Player player, Runnable runnable);
+    public abstract void runGlobal(Runnable runnable);
+
+    public abstract void runLater(Player player, Runnable runnable, long delay);
+
+    public abstract void runTimer(Player player, Runnable runnable, long delay, long period);
+
+    public static Scheduler createScheduler(JavaPlugin plugin) {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler");
+            return new PaperScheduler(plugin);
+        } catch (Exception e) {
+            return new BukkitScheduler(plugin);
+        }
+    }
+}

--- a/src/main/java/dev/aurelium/slate/scheduler/Scheduler.java
+++ b/src/main/java/dev/aurelium/slate/scheduler/Scheduler.java
@@ -10,12 +10,12 @@ public abstract class Scheduler {
         this.plugin = plugin;
     }
 
-    public abstract void run(Player player, Runnable runnable);
-    public abstract void runGlobal(Runnable runnable);
+    public abstract WrappedTask run(Player player, Runnable runnable);
+    public abstract WrappedTask runGlobal(Runnable runnable);
 
-    public abstract void runLater(Player player, Runnable runnable, long delay);
+    public abstract WrappedTask runLater(Player player, Runnable runnable, long delay);
 
-    public abstract void runTimer(Player player, Runnable runnable, long delay, long period);
+    public abstract WrappedTask runTimer(Player player, Runnable runnable, long delay, long period);
 
     public static Scheduler createScheduler(JavaPlugin plugin) {
         try {

--- a/src/main/java/dev/aurelium/slate/scheduler/WrappedTask.java
+++ b/src/main/java/dev/aurelium/slate/scheduler/WrappedTask.java
@@ -1,5 +1,7 @@
 package dev.aurelium.slate.scheduler;
 
+import java.lang.reflect.Method;
+
 public class WrappedTask {
     private Object originalTask;
 
@@ -10,7 +12,9 @@ public class WrappedTask {
     public void cancel() {
         // Call cancel method using reflection
         try {
-            originalTask.getClass().getMethod("cancel").invoke(originalTask);
+            Method method = originalTask.getClass().getMethod("cancel");
+            method.setAccessible(true);
+            method.invoke(originalTask);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/dev/aurelium/slate/scheduler/WrappedTask.java
+++ b/src/main/java/dev/aurelium/slate/scheduler/WrappedTask.java
@@ -1,0 +1,18 @@
+package dev.aurelium.slate.scheduler;
+
+public class WrappedTask {
+    private Object originalTask;
+
+    public WrappedTask(Object originalTask) {
+        this.originalTask = originalTask;
+    }
+
+    public void cancel() {
+        // Call cancel method using reflection
+        try {
+            originalTask.getClass().getMethod("cancel").invoke(originalTask);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
This should probably cut it though for folia support. Schedulers are separated both for spigot and paper (folia) and the open call is invoked on the player's thread. Command dispatching also moved to the proper schedulers.

I'm gonna be honest, I don't want to mess with maven local repository and with any annoying toolchain stuff to include this into AuraSkills to test it properly. Though you should be able to test it with the Folia PR on AuraSkills, and it should work properly. If not, tell me and I will fix it.

